### PR TITLE
Force unwraps on GetAssetById and total amount overflowing Int64

### DIFF
--- a/Sources/swift-algorand-sdk/model/AssetParamsData.swift
+++ b/Sources/swift-algorand-sdk/model/AssetParamsData.swift
@@ -1,38 +1,38 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Jesulonimi on 3/1/21.
 //
 
 import Foundation
 
-public class AssetParamsData : Codable{
-         public var clawback:String?;
-           public var creator:String?;
-            public var decimals:Int64?;
-            public var defaultFrozen:Bool?;
-          public var freeze:String?;
-           public var manager:String?;
-            public var metadataHash:[Int8]?;
-        public var name:String?;
-           public var reserve:String?;
-         public var total:Int64?;
-             public var unitName:String?;
-       public var url:String?;
-    
-    enum CodingKeys:String,CodingKey{
-       
-           case clawback="clawback"
-           case creator="creator";
-           case decimals="decimals";
-           case defaultFrozen="default-frozen";
-           case freeze="freeze";
-           case manager="manager";
-          case name="name"
-          case reserve="reserve";
-           case total="total";
-           case unitName="unit-name";
-          case url="url";
+public class AssetParamsData: Codable {
+    public var clawback: String?
+    public var creator: String?
+    public var decimals: Int64?
+    public var defaultFrozen: Bool?
+    public var freeze: String?
+    public var manager: String?
+    public var metadataHash: [Int8]?
+    public var name: String?
+    public var reserve: String?
+    // Possibily breaking change if anyone have based their local implementations around Int64. However, this is leading some JSON decoding to failures due to really big amounts (overflowing Int64)
+    public var total: Double?
+    public var unitName: String?
+    public var url: String?
+
+    enum CodingKeys: String, CodingKey {
+        case clawback
+        case creator
+        case decimals
+        case defaultFrozen = "default-frozen"
+        case freeze
+        case manager
+        case name
+        case reserve
+        case total
+        case unitName = "unit-name"
+        case url
     }
 }

--- a/Sources/swift-algorand-sdk/v2/client/algod/GetAssetById.swift
+++ b/Sources/swift-algorand-sdk/v2/client/algod/GetAssetById.swift
@@ -1,60 +1,63 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Jesulonimi on 5/3/21.
 //
 
-import Foundation
 import Alamofire
-public class GetAssetById{
-    var client:AlgodClient
+import Foundation
+public class GetAssetById {
+    var client: AlgodClient
 
-    var assetId:Int64
-    init(client:AlgodClient,assetId:Int64) {
-        self.client=client
-        self.assetId=assetId
+    var assetId: Int64
+    init(client: AlgodClient, assetId: Int64) {
+        self.client = client
+        self.assetId = assetId
     }
 
-    public func execute( callback: @escaping (_:Response<  AssetData>) ->Void){
+    public func execute(callback: @escaping (_: Response<AssetData>) -> Void) {
 //        print(getRequestString(parameter: self.assetId))
-        let headers:HTTPHeaders=[client.apiKey:client.token]
-        var request=AF.request(getRequestString(parameter: self.assetId),method: .get, parameters: nil, headers: headers,requestModifier: { $0.timeoutInterval = 120 })
+        let headers: HTTPHeaders = [client.apiKey: client.token]
+        var request = AF.request(getRequestString(parameter: assetId),
+                                 method: .get,
+                                 parameters: nil,
+                                 headers: headers,
+                                 requestModifier: { $0.timeoutInterval = 120 })
         request.validate()
-        var customResponse:Response<AssetData>=Response()
- 
-     
-        request.responseDecodable(of:  AssetData.self){  (response) in
+        var customResponse: Response<AssetData> = Response()
 
-    if(response.error != nil){
-        
-        customResponse.setIsSuccessful(value:false)
-        var errorDescription=String(data:response.data ?? Data(response.error!.errorDescription!.utf8),encoding: .utf8)
-        customResponse.setErrorDescription(errorDescription:errorDescription!)
-        callback(customResponse)
-        if(response.data != nil){
-            if let message = String(data: response.data!,encoding: .utf8){
-                var errorDic = try! JSONSerialization.jsonObject(with: message.data, options: []) as? [String: Any]
-                customResponse.errorMessage = errorDic!["message"] as! String
+        request.responseDecodable(of: AssetData.self) { response in
+
+            if response.error != nil {
+                customResponse.setIsSuccessful(value: false)
+                var errorDescription = String(data: response.data ?? Data((response.error?.errorDescription ?? "").utf8), encoding: .utf8)
+                customResponse.setErrorDescription(errorDescription: errorDescription ?? "")
+                callback(customResponse)
+                if response.data != nil {
+                    if let message = String(data: response.data ?? Data(), encoding: .utf8),
+                       let errorDic = (try? JSONSerialization.jsonObject(with: message.data, options: [])) as? [String: Any]
+                    {
+                        // This force unwrap was causing an error when response is a proper 200 from server, but local Swift Decoding is failing.
+                        customResponse.errorMessage = errorDic["message"] as? String ?? "Error not available"
+                    } else {
+                        customResponse.errorMessage = "Error not available"
+                    }
+                }
+                return
             }
 
+            guard let data = response.value else { return }
+            var assetResponse: AssetData = data
+            customResponse.setData(data: assetResponse)
+            customResponse.setIsSuccessful(value: true)
+            callback(customResponse)
         }
-        return
-    }
-        
-                    let data=response.value
-                    var assetResponse:AssetData=data!
-                    customResponse.setData(data:assetResponse)
-                    customResponse.setIsSuccessful(value:true)
-                    callback(customResponse)
-
-    }
     }
 
-    internal func getRequestString(parameter:Int64)->String {
-        var component=client.connectString()
-        component.path = component.path+"/v2/assets/\(assetId)"
-        return component.url!.absoluteString;
-        
+    internal func getRequestString(parameter _: Int64) -> String {
+        var component = client.connectString()
+        component.path = component.path + "/v2/assets/\(assetId)"
+        return component.url?.absoluteString ?? ""
     }
 }


### PR DESCRIPTION
fixes #8 
fixes #7 

Main thing I did here is getting rid of force unwraps and give code a SwiftLint pass to improve readability.

This PR fix a specific crash we've found related to #7