### PR TITLE
Fix encoding parameter not set to AF request

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-algorand-sdk.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-algorand-sdk.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "swift-algorand-sdk_swift-algorand-sdkTests"
+               BuildableName = "swift-algorand-sdk_swift-algorand-sdkTests"
+               BlueprintName = "swift-algorand-sdk_swift-algorand-sdkTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,8 @@ let package = Package(
       
         .testTarget(
             name: "swift-algorand-sdkTests",
-            dependencies: ["swift-algorand-sdk"]
+            dependencies: ["swift-algorand-sdk"],
+            resources: [.process("mocks")]
         ),
         
     ]

--- a/Sources/swift-algorand-sdk/v2/client/Request.swift
+++ b/Sources/swift-algorand-sdk/v2/client/Request.swift
@@ -50,10 +50,11 @@ public struct RequestParameters {
         components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
         let headers = self.headers.merging(client.defaultHTTPHeaders) { _, global in global  }
         return client.session.request(components.url?.absoluteString ?? "",
-                          method: method,
-                          parameters: bodyParameters,
-                          headers: .init(headers),
-                          requestModifier: { $0.timeoutInterval = 120.0 })
+                                      method: method,
+                                      parameters: bodyParameters,
+                                      encoding: encoding,
+                                      headers: .init(headers),
+                                      requestModifier: { $0.timeoutInterval = 120.0 })
             .validate()
     }
 }

--- a/Tests/swift-algorand-sdkTests/AlgodClientTests.swift
+++ b/Tests/swift-algorand-sdkTests/AlgodClientTests.swift
@@ -109,9 +109,17 @@ public class AlgodClientTests: XCTestCase {
     }
     
     func testGetVersion() {
-        let object = Version(build: .init(build_number: 1234))
+        let object = Version(build: .init(branch: "theBranch",
+                                          build_number: 123, 
+                                          channel: "theChannel",
+                                          commit_hash: "theCommitHash",
+                                          major: 123,
+                                          minor: 123),
+                             genesis_hash_string: "123",
+                             genesis_id: "1234",
+                             versions: ["1.0", "2.0"])
         let request = GetVersion(client: client)
-        assertSuccessfulResponse(for: request, with: object)
+        assertSuccessfulResponse(for: request, json: "versions", with: object)
         assertErrorResponse(for: request)
     }
     

--- a/Tests/swift-algorand-sdkTests/mocks/algod/versions.json
+++ b/Tests/swift-algorand-sdkTests/mocks/algod/versions.json
@@ -1,0 +1,16 @@
+{
+  "genesis_hash_b64": "123",
+  "genesis_id": "1234",
+  "versions": [
+    "1.0",
+    "2.0"
+  ],
+  "build": {
+    "branch": "theBranch",
+    "build_number": 123,
+    "channel": "theChannel",
+    "commit_hash": "theCommitHash",
+    "major": 123,
+    "minor": 123
+  }
+}


### PR DESCRIPTION
With my previous PR i totally forgot to add the `encoding` parameter to the shared Alamofire request creation.

This was resulting in a serverside error for all `POST` requests.

> Unfortunately this kind of problems is practically impossible to unit test, as they depend on real server interaction